### PR TITLE
write bookings show endpoint multiple sad paths

### DIFF
--- a/app/controllers/api/v1/bookings_controller.rb
+++ b/app/controllers/api/v1/bookings_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1
+    class BookingsController < ApplicationController
+      before_action :validate_params, only: :show
+
+      def show
+        booking = Booking.find(params[:id])
+        render json: BookingSerializer.new(booking)
+      end
+
+      private
+      def validate_params
+        if params[:id].to_i == 0
+          render json: {error: "String not accepted as id"}, status: :bad_request
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/booking_serializer.rb
+++ b/app/serializers/booking_serializer.rb
@@ -1,0 +1,5 @@
+class BookingSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :status, :yard_id, :booking_name, :renter_id, :date, :time,
+    :duration, :description
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :purposes, only: [:index]
       resources :yards, except: [:index]
+      resources:bookings, only: [:show]
     end
   end
 end

--- a/spec/requests/api/v1/bookings_show_spec.rb
+++ b/spec/requests/api/v1/bookings_show_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'Bookings API SPEC'do
+  describe 'happy path' do
+    it 'can return a specific booking by id' do
+      create_list(:booking, 10)
+      booking_id = Booking.all.first
+      get "/api/v1/bookings/#{booking_id.id}"
+      expect(response).to be_successful
+      booking = JSON.parse(response.body, symbolize_names:true)
+      expect(booking).to be_a(Hash)
+      expect(booking[:data]).to be_a(Hash)
+      expect(booking[:data].count).to eq(3)
+      expect(booking[:data][:attributes].count).to eq(8)
+      expect(booking[:data][:attributes]).to have_key(:status)
+      expect(booking[:data][:attributes]).to have_key(:booking_name)
+      expect(booking[:data][:attributes]).to have_key(:date)
+      expect(booking[:data][:attributes]).to have_key(:description)
+      expect(booking[:data][:attributes]).to have_key(:duration)
+      expect(booking[:data][:attributes]).to have_key(:time)
+      expect(booking[:data][:attributes]).to have_key(:renter_id)
+      expect(booking[:data][:attributes]).to have_key(:yard_id)
+      expect(booking[:data][:attributes][:renter_id]).to be_a(Integer)
+      expect(booking[:data][:attributes][:yard_id]).to be_a(Integer)
+      expect(booking[:data][:attributes][:duration]).to be_a(Integer)
+      expect(booking[:data][:attributes][:description]).to be_a(String)
+      expect(booking[:data][:attributes][:status]).to be_a(String)
+      expect(booking[:data][:attributes][:booking_name]).to be_a(String)
+      expect(booking[:data][:attributes][:time]).to be_a(String)
+    end
+
+    it 'returns the correct booking' do
+      create_list(:booking, 10)
+      booking = create(:booking, status: :approved, booking_name: "fun", duration:100)
+      special_booking = Booking.all.last
+      get "/api/v1/bookings/#{special_booking.id}"
+      expect(response).to be_successful
+      booking = JSON.parse(response.body, symbolize_names:true)
+      expect(booking[:data][:attributes][:renter_id]).to eq(special_booking.renter_id)
+      expect(booking[:data][:attributes][:yard_id]).to eq(special_booking.yard_id)
+      expect(booking[:data][:attributes][:duration]).to eq(special_booking.duration)
+      expect(booking[:data][:attributes][:status]).to eq(special_booking.status)
+      expect(booking[:data][:attributes][:booking_name]).to eq(special_booking.booking_name)
+      expect(booking[:data][:attributes][:description]).to eq(special_booking.description)
+    end
+  end
+
+  describe 'sad path' do
+    it 'errors out when no bookings match id' do
+      create_list(:booking, 10)
+      booking = create(:booking, status: :approved, booking_name: "fun", duration:100)
+      get "/api/v1/bookings/akjfkjkjkd"
+      expect(response.status).to eq(400)
+      error = JSON.parse(response.body, symbolize_names:true)
+      expect(error).to be_a(Hash)
+      expect(error[:error]).to be_a(String)
+    end
+
+    it 'should return an empty array if no ids exist' do
+      create_list(:booking, 10)
+      booking = create(:booking, status: :approved, booking_name: "fun", duration:100)
+      get "/api/v1/bookings/100000000"
+      expect(response.status).to eq(404)
+      expect(response.body).to eq("Record not found")
+    end
+  end
+end


### PR DESCRIPTION
Created bookings show page endpoint 


testing
multiple sad paths if anyone has any others I can add them 